### PR TITLE
Fix bash compatibility for CentOS 6

### DIFF
--- a/assets/build
+++ b/assets/build
@@ -41,6 +41,6 @@ find ${RPM_BUILD_SRPMS} -name "${COMPONENT}*.rpm" \
     -exec mv {} ${OUTPUT} \;
 
 # fix uids
-if [ -v OUTPUT_UID ]; then
+if [ -z "${OUTPUT_UID}" ]; then
    chown -R ${OUTPUT_UID}:${OUTPUT_UID} ${OUTPUT}/*
 fi


### PR DESCRIPTION
When .spec's `%build` section fails due to e.g. not-expanded macro, I seem to get this error:

`/usr/bin/build: line 44: [: -v: unary operator expected` 

The bash in CentOS 6 is too old to support `v OUTPUT_UID` construct, so the pull request is to replace this with something more compatible.