### PR TITLE
Proper exit code for "docker run", rpmlint checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Available versions can be located by visiting [Docker Hub Repository](https://hub.docker.com/r/alectolytic/rpmbuilder/tags/).
 
 ### Fetch image
-```
+```bash
 BUILDER_VERSION=centos-7
 docker pull alectolytic/rpmbuilder:${BUILDER_VERSION}
 ```
@@ -12,7 +12,7 @@ docker pull alectolytic/rpmbuilder:${BUILDER_VERSION}
 ### Run
 In this example `SOURCE_DIR` contains spec file and sources for the the RPM we are building.
 
-```
+```bash
 # set env variables for conviniece
 SOURCE_DIR=$(pwd)/sources
 OUTPUT_DIR=$(pwd)/output
@@ -35,7 +35,7 @@ The output files will be available in `OUTPUT_DIR`.
 ###  Debugging
 If you are creating a spec file, it is often useful to have a clean room debugging environment. You can achieve this by using the following command.
 
-```
+```bash
 docker run --rm -it --entrypoint bash \
     -v ${SOURCE_DIR}:/sources \
     -v ${OUTPUT_DIR}:/output \

--- a/assets/build
+++ b/assets/build
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
+# use exit codes of failing commands
+set -exo pipefail
+
 SOURCES=${SOURCES-/sources}
 OUTPUT=${OUTPUT-${SOURCES}}
 WORKSPACE=${WORKSPACE-/workspace}
-
-[[ -z ${SRPM_ONLY} ]] \
-    && RPMBUILD_MODE="-ba" \
-    || RPMBUILD_MODE="-bs"
 
 RPM_BUILD_SOURCES=$(rpmbuild --eval '%{_sourcedir}')
 RPM_BUILD_RPMS=$(rpmbuild --eval '%{_rpmdir}')
@@ -25,20 +24,33 @@ find ${WORKSPACE} -mindepth 1 -maxdepth 1 ! -name "*.spec" \
 BUILDDEP_CMD=yum-builddep
 command -v dnf > /dev/null 2>&1 && BUILDDEP_CMD="dnf builddep"
 
-# install deps and fetch any external sources
-# then do an RPM BUILD
-find ${WORKSPACE} -maxdepth 1 -type f -name "*.spec" \
-    -exec ${BUILDDEP_CMD} -y {} \; \
-    -exec spectool --sourcedir --get-files {} \; \
-    -exec rpmbuild ${RPMBUILD_OPTS} ${RPMBUILD_MODE} --clean {} \;
+for specFile in ${WORKSPACE}/*.spec; do
+  # install build requires
+  ${BUILDDEP_CMD} -y $specFile
+  spectool --sourcedir --get-files $specFile
 
-# extract RPMs
-find ${RPM_BUILD_RPMS} -name "${COMPONENT}*.rpm" \
-    -exec mv {} ${OUTPUT} \;
+  # build SRPM, also allows to fail quicker
+  rpmbuild -bs $specFile
 
-# extract SRPMs
-find ${RPM_BUILD_SRPMS} -name "${COMPONENT}*.rpm" \
-    -exec mv {} ${OUTPUT} \;
+  if [[ -n ${RPMLINT} ]]; then
+    # SRPM built successfully. Check it using rpmlint
+    rpmlint ${RPM_BUILD_SRPMS}/*.rpm
+  fi
+
+  mv ${RPM_BUILD_SRPMS}/*.rpm ${OUTPUT}
+
+  if [[ -z ${SRPM_ONLY} ]]; then
+    # attempting to build RPM now
+    rpmbuild -ba $specFile
+
+    if [[ -n ${RPMLINT} ]]; then
+      # RPM built successfully. Check it using rpmlint
+      rpmlint ${RPM_BUILD_RPMS}/*/*.rpm
+    fi
+
+    mv ${RPM_BUILD_RPMS}/*/*.rpm ${OUTPUT}
+  fi
+done
 
 # fix uids
 if [ -z "${OUTPUT_UID}" ]; then

--- a/crypt-keeper
+++ b/crypt-keeper
@@ -20,7 +20,7 @@ function generate() {
     cp -R ./assets ${ROOT}/.
     # cp LICENCE README.md
     YUM="yum"
-    PACKAGES="rpm-build rpmdevtools yum-utils"
+    PACKAGES="rpm-build rpmdevtools yum-utils rpmlint"
     case "${DISTRO}" in
         centos|cloudrouter*centos)
             EXTRA_PACKAGES="epel-release";


### PR DESCRIPTION
Currently `docker run` will exit with 0 status code no matter if (S)RPMs were successfully built.
In the following changes, the `build` script will exit with any failed command's exit status code. Thus, the whole thing is more suitable for testing `.spec` files.

It will also fail more quickly in case there's an error in a spec file by always building SRPM first. This allows for quicker `.spec` files tests.

Adds optional `rpmlint` support and fail on its errors, by passing `RPMLINT=1` (will fail on `rpmlint` errors).