### PR TITLE
Add Fedora 29 build in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: generic
 
 env:
   matrix:
+    - OS_TYPE=fedora OS_VERSION=29
     - OS_TYPE=fedora OS_VERSION=28
     - OS_TYPE=fedora OS_VERSION=27
     - OS_TYPE=fedora OS_VERSION=26


### PR DESCRIPTION
You might also consider a removal of Fedora 26 and 27 as they reached the EOL and are no longer maintained (including security patches).