### PR TITLE
ci: Add fedora 38

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -20,6 +20,8 @@ jobs:
             version: 36
           - distro: fedora
             version: 37
+          - distro: fedora
+            version: 38
           - distro: centos
             version: 7
           - distro: rockylinux


### PR DESCRIPTION
Hi,
I wanted to update the throttled-rpm repo to Fedora 38 and noticed that first a new rpmbuilder image for Fedora 38 needs to be created.
I added Fedora 38 to the Matrix and let the Action run. All images build and tested successfully on my branch.