### PR TITLE
feat: support injecting corporate CA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,19 @@ The following configurations are available via environment variables
 
 The following volumes can be mounted from the host.
 
-| Volume   | Description                                                      |
-|:---------|:-----------------------------------------------------------------|
-| /sources | Source to build RPM from                                         |
-| /output  | Output directory where all built RPMs and SRPMs are extracted to |
+| Volume                                  | Description                                                      |
+|:----------------------------------------|:-----------------------------------------------------------------|
+| /sources                                | Source to build RPM from                                         |
+| /output                                 | Output directory where all built RPMs and SRPMs are extracted to |
+| /etc/pki/ca-trust/source/anchors        | (optional) Directory of `.crt` files to add to the CA trust store before building |
+
+To inject corporate or self-signed CA certificates, mount a directory containing `.crt` files and the trust store will be updated automatically before any build steps run:
+
+```bash
+podman run --rm -it \
+    -v ${SOURCE_DIR}:/sources:z \
+    -v ${OUTPUT_DIR}:/output:z \
+    -v ${CERT_DIR}:/etc/pki/ca-trust/source/anchors:z \
+    -e OUTPUT_USER=$UID \
+    quay.io/abn/rpmbuilder:${BUILDER_VERSION}
+```

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -23,7 +23,7 @@ if [[ "${PACKAGE_MANAGER}" == "dnf" ]]; then
   ${PACKAGE_MANAGER} -y install "dnf-command(builddep)"
 fi
 
-${PACKAGE_MANAGER} -y install rpm-build rpmdevtools yum-utils rpmlint ${EXTRA_PACKAGES}
+${PACKAGE_MANAGER} -y install ca-certificates rpm-build rpmdevtools yum-utils rpmlint ${EXTRA_PACKAGES}
 
 ${PACKAGE_MANAGER} -y clean all
 

--- a/rpmbuilder.sh
+++ b/rpmbuilder.sh
@@ -23,6 +23,14 @@ install \
 
 { command -v dnf > /dev/null 2>&1 && DNF=1; } || :
 
+CA_ANCHORS_DIR="/etc/pki/ca-trust/source/anchors"
+if compgen -G "${CA_ANCHORS_DIR}/*" > /dev/null 2>&1; then
+  UPDATE_CA_CMD=()
+  [[ $EUID -ne 0 ]] && UPDATE_CA_CMD+=(sudo)
+  UPDATE_CA_CMD+=(update-ca-trust extract)
+  "${UPDATE_CA_CMD[@]}"
+fi
+
 # prepare builddep-command
 BUILDDEP_CMD=()
 if [[ $EUID -ne 0 ]]; then


### PR DESCRIPTION
Mount a directory of .crt files to /etc/pki/ca-trust/source/anchors and update-ca-trust extract is called automatically before any build steps, enabling use behind corporate firewalls with self-signed certs. Ensures ca-certificates is installed in all built images.

Resolves: #7