### PR TITLE
feat: add FROM_SRPM rebuild mode and two-stage tito workflow

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -40,6 +40,11 @@ jobs:
         env:
           TARGET_IMAGE: rpmbuilder:${{ matrix.distro }}-${{ matrix.version }}
         run: ./bin/test.sh
+      - name: Test Tito Workflow
+        if: matrix.tito != 'false'
+        env:
+          TARGET_IMAGE: rpmbuilder:${{ matrix.distro }}-${{ matrix.version }}
+        run: ./bin/test-tito.sh
       - name: Publish Image (quay.io)
         if: github.ref == 'refs/heads/main'
         env:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ podman pull quay.io/abn/rpmbuilder:${BUILDER_VERSION}
 In this example `SOURCE_DIR` contains spec file and sources for the the RPM we are building.
 
 ```bash
-# set env variables for conviniece
+# set env variables for convenience
 SOURCE_DIR=$(pwd)/sources
 OUTPUT_DIR=$(pwd)/output
 
@@ -37,6 +37,44 @@ podman run --rm -it \
 ```
 
 The output files will be available in `OUTPUT_DIR`.
+
+### Tito projects
+
+For projects managed by [tito](https://github.com/rpm-software-management/tito), use the same image as for spec-based builds. The image detects the presence of a `.tito` directory and automatically installs tito at runtime before building with `tito build --test`:
+
+```bash
+podman run --rm -it \
+    -v ${SOURCE_DIR}:/sources:z \
+    -v ${OUTPUT_DIR}:/output:z \
+    -e OUTPUT_USER=$UID \
+    quay.io/abn/rpmbuilder:${BUILDER_VERSION}
+```
+
+> **Note:** tito is available via EPEL on Fedora and EL 8/9 but is not yet available on EL 10 (e.g. Rocky Linux 10).
+
+#### Two-stage tito workflow (strict dependency isolation)
+
+Because tito and its dependencies are installed into the build environment at runtime, they could inadvertently satisfy undeclared `BuildRequires` in a spec file. To ensure only explicitly declared dependencies are used, run the build in two stages: generate the SRPM with tito in the first run, then rebuild the RPM from that SRPM in a second clean run without tito present.
+
+```bash
+# Stage 1: generate SRPM using tito
+podman run --rm -it \
+    -v ${SOURCE_DIR}:/sources:z \
+    -v ${OUTPUT_DIR}:/output:z \
+    -e OUTPUT_USER=$UID \
+    -e SRPM_ONLY=1 \
+    quay.io/abn/rpmbuilder:${BUILDER_VERSION}
+
+# Stage 2: rebuild RPM from SRPM in a clean environment (no tito)
+podman run --rm -it \
+    -v ${OUTPUT_DIR}:/sources:z \
+    -v ${OUTPUT_DIR}:/output:z \
+    -e OUTPUT_USER=$UID \
+    -e FROM_SRPM=1 \
+    quay.io/abn/rpmbuilder:${BUILDER_VERSION}
+```
+
+The `FROM_SRPM=1` flag is required and intentional — it prevents the image from accidentally entering SRPM rebuild mode due to leftover `.src.rpm` files in the output directory.
 
 ### Debugging
 
@@ -57,12 +95,14 @@ file. You can also iteratively modify the specfile and re-run `build`.
 
 The following configurations are available via environment variables
 
-| Variable | Description                                                    |
-|:---------|:---------------------------------------------------------------|
-| SOURCES  | Configure source directory on the container file system        |
-| OUTPUT   | Configure output directory on the container file system        |
-| RPM_LINT | If set, enables rpm linting once rpms are built                |
-| ARCH     | Target architecture to build the rpm for, defaults to `x86_64` |
+| Variable   | Description                                                                                      |
+|:-----------|:-------------------------------------------------------------------------------------------------|
+| SOURCES    | Configure source directory on the container file system                                          |
+| OUTPUT     | Configure output directory on the container file system                                          |
+| RPM_LINT   | If set, enables rpm linting once rpms are built                                                  |
+| ARCH       | Target architecture to build the rpm for, defaults to `x86_64`                                  |
+| SRPM_ONLY  | If set, only builds and outputs the SRPM; skips binary RPM build                                 |
+| FROM_SRPM  | If set, treats `SOURCES` as a directory of `.src.rpm` files and rebuilds RPMs from them; use with the base image as stage 2 of the [two-stage tito workflow](#two-stage-tito-workflow-strict-dependency-isolation) |
 
 ## Volumes
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -8,7 +8,7 @@ EXTRA_PACKAGES=${EXTRA_PACKAGES:-""}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-docker build -t ${TARGET_IMAGE} -f - ${DIR}/../ << EOF
+docker build -t "${TARGET_IMAGE}" -f - "${DIR}"/../ << EOF
 FROM ${BASE_IMAGE}
 
 ARG EXTRA_PACKAGES

--- a/bin/test-tito.sh
+++ b/bin/test-tito.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -ex
+
+TARGET_IMAGE=${2:-${TARGET_IMAGE:-$USER/rpmbuilder}}
+
+# Test: single-container tito build (tito installed at runtime)
+docker run --rm -i -e OUTPUT_USER=1500 --entrypoint bash "${TARGET_IMAGE}" -s <<'EOF'
+set -exo pipefail
+shopt -s globstar extglob nullglob
+
+PACKAGE_MANAGER=$({ command -v dnf > /dev/null 2>&1 && echo "dnf"; } || echo "yum")
+${PACKAGE_MANAGER} -y install git
+
+git clone https://github.com/abn/hello-rpm-tito.git "${SOURCES}"
+
+/usr/bin/rpmbuilder
+
+[ "$(ls -A ${OUTPUT})" ]
+${PACKAGE_MANAGER} -y install ${OUTPUT}/!(*.src).rpm
+EOF
+
+# Test: two-stage build with strict dependency isolation
+SRPM_DIR=$(mktemp -d)
+OUTPUT_DIR=$(mktemp -d)
+trap "rm -rf ${SRPM_DIR} ${OUTPUT_DIR}" EXIT
+
+# Stage 1: generate SRPM; tito installed at runtime, sources cloned inside container
+docker run --rm -i \
+  -v "${SRPM_DIR}":/output:z \
+  -e OUTPUT_USER=1500 \
+  -e SRPM_ONLY=1 \
+  --entrypoint bash "${TARGET_IMAGE}" -s <<'EOF'
+set -exo pipefail
+shopt -s globstar extglob nullglob
+
+PACKAGE_MANAGER=$({ command -v dnf > /dev/null 2>&1 && echo "dnf"; } || echo "yum")
+${PACKAGE_MANAGER} -y install git
+
+git clone https://github.com/abn/hello-rpm-tito.git "${SOURCES}"
+
+/usr/bin/rpmbuilder
+
+compgen -G "${OUTPUT}/*.src.rpm" > /dev/null
+EOF
+
+# Stage 2: rebuild RPM from SRPM in a clean environment
+docker run --rm -i \
+  -v "${SRPM_DIR}":/sources:z \
+  -v "${OUTPUT_DIR}":/output:z \
+  -e OUTPUT_USER=1500 \
+  -e FROM_SRPM=1 \
+  --entrypoint bash "${TARGET_IMAGE}" -s <<'EOF'
+set -exo pipefail
+shopt -s globstar extglob nullglob
+
+/usr/bin/rpmbuilder
+
+[ "$(ls -A ${OUTPUT})" ]
+PACKAGE_MANAGER=$({ command -v dnf > /dev/null 2>&1 && echo "dnf"; } || echo "yum")
+$PACKAGE_MANAGER -y install ${OUTPUT}/!(*.src).rpm
+EOF

--- a/rpmbuilder.sh
+++ b/rpmbuilder.sh
@@ -78,19 +78,52 @@ function build-from-spec() {
 
 }
 
-function build-from-tito() {
-  echo "tito project detected. Installing tito..."
-  local SUDO_CMD=()
-  if [[ $EUID -ne 0 ]]; then
-    SUDO_CMD+=(sudo)
+function rebuild-from-srpm() {
+  local srpmFiles=("${SOURCES}"/*.src.rpm)
+
+  if [[ ! -f "${srpmFiles[0]}" ]]; then
+    echo "FROM_SRPM is set but no .src.rpm files found in ${SOURCES}" >&2
+    exit 1
   fi
 
-  if [[ -n "${DNF}" ]]; then
-    "${SUDO_CMD[@]}" dnf install -y tito
-  else
-    "${SUDO_CMD[@]}" yum install -y tito
+  for srpm in "${srpmFiles[@]}"; do
+    "${BUILDDEP_CMD[@]}" -y "$srpm"
+    rpmbuild --rebuild --target "${ARCH}" "$srpm"
+
+    local prefix
+    prefix=$(rpm -qp --queryformat '%{name}-%{version}-%{release}' "$srpm")
+
+    for rpm in "${RPM_BUILD_SRPMS}/${prefix}"*.rpm "${RPM_BUILD_RPMS}"/**/"${prefix}"*.rpm; do
+      if [[ -n "${RPM_LINT}" ]]; then
+        rpmlint --verbose --info "$rpm"
+      fi
+      install \
+        --owner "${OUTPUT_USER}" --group "${OUTPUT_USER}" \
+        --target-directory "${OUTPUT}" \
+        "$rpm"
+    done
+  done
+}
+
+function build-from-tito() {
+  if ! command -v tito > /dev/null 2>&1; then
+    echo "tito not found. Installing tito..."
+    local SUDO_CMD=()
+    if [[ $EUID -ne 0 ]]; then
+      SUDO_CMD+=(sudo)
+    fi
+
+    if { [[ -n "${DNF}" ]] && "${SUDO_CMD[@]}" dnf install -y tito; } \
+        || "${SUDO_CMD[@]}" yum install -y tito; then
+      :
+    else
+      local PKG_MGR; [[ -n "${DNF}" ]] && PKG_MGR=dnf || PKG_MGR=yum
+      "${SUDO_CMD[@]}" "${PKG_MGR}" install -y python3 python3-setuptools
+      python3 -m ensurepip
+      python3 -m pip install tito
+    fi
   fi
-  
+
   echo "Building tito test release..."
   local TITO_OUTPUT=$(mktemp -d)
   
@@ -130,7 +163,9 @@ for specFile in "${specFiles[@]}"; do
   spectool --sourcedir --get-files "$specFile"
 done
 
-if [[ -d "${SOURCES}/.tito" ]]; then
+if [[ -n "${FROM_SRPM}" ]]; then
+  rebuild-from-srpm
+elif [[ -d "${SOURCES}/.tito" ]]; then
   build-from-tito
 else
   for specFile in "${specFiles[@]}"; do


### PR DESCRIPTION
Add FROM_SRPM mode to rebuild RPMs from an existing .src.rpm in a clean environment, enabling strict BuildRequires isolation as a two-stage complement to the tito flow.

Fall back to pip when tito is unavailable via the package manager, enabling support on Rocky Linux where tito is not in EPEL.

Add CI tests covering both the single-container tito flow and the two-stage SRPM rebuild. Document the workflow and update the configuration reference.